### PR TITLE
Commander kill XP reward

### DIFF
--- a/ZeroWars.sdd/LuaRules/Gadgets/ZeroWars/Custom_Commanders.lua
+++ b/ZeroWars.sdd/LuaRules/Gadgets/ZeroWars/Custom_Commanders.lua
@@ -5,6 +5,11 @@ local custom_com_defs = include("LuaRules/Configs/custom_com_defs.lua")
 CustomCommanders = {}
 CustomCommanders.__index = CustomCommanders
 
+CustomCommanders.comm_costs = {200}
+for lvl=1,18 do
+    CustomCommanders.comm_costs[lvl] = CustomCommanders.comm_costs[lvl-1] + 250 * (lvl - 1)
+end
+
 function CustomCommanders:new ()
     local o = {}
     setmetatable(o, CustomCommanders)
@@ -55,6 +60,12 @@ function CustomCommanders:TransferExperience(unitID, unitTeam)
         end
         Spring.GiveOrderToUnit(original, CMD.FIRE_STATE, {2}, 0)
     end
+end
+
+function CustomCommanders.CalculateReward(attackerLvl, victimLvl)
+    local attackerCost = CustomCommanders.comm_costs[attackerLvl]
+    local victimCost = CustomCommanders.comm_costs[victimLvl]
+    return math.max(0, victimCost / attackerCost - 1.0)
 end
 
 function CustomCommanders:IsCommander(unitDefID)

--- a/ZeroWars.sdd/LuaRules/Gadgets/zero_wars.lua
+++ b/ZeroWars.sdd/LuaRules/Gadgets/zero_wars.lua
@@ -146,6 +146,13 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerD
         end
     end
     if attackerDefID and customCommanders:IsCommander(attackerDefID) and customCommanders:HasCommander(attackerTeam) then
+        if customCommanders:IsCommander(unitDefID) then
+            local attackerLevel = Spring.GetUnitRulesParam(attackerID, "level")
+            local victimLevel = Spring.GetUnitRulesParam(unitID, "level")
+            local reward = CustomCommanders.CalculateReward(attackerLevel, victimLevel)
+            local xp = Spring.GetUnitExperience(attackerID) + reward
+            Spring.SetUnitExperience(attackerID, xp)
+        end
         customCommanders:TransferExperience(attackerID, attackerTeam)
     end
 end


### PR DESCRIPTION
Give more XP for killing a higher level Duck Commander.  Using the table in #23

I didn't see a way to modify the unitDef `power` for a unit so this will not affect target priority or reduce XP for killing lower levels.  If you know a Springy way to do this let me know and I'll fix it.  Otherwise it looks like the engine would need a new SyncedCtrl to modify this.