### PR TITLE
Add hero moderator, fix upgrade descriptions, fix wrong puppy armor upgrade

### DIFF
--- a/ZeroWars.sdd/LuaRules/Configs/Hero_Unit_Defs.lua
+++ b/ZeroWars.sdd/LuaRules/Configs/Hero_Unit_Defs.lua
@@ -79,21 +79,21 @@ local HeroUpgradeDefs = {
             },
             [2] = {
                 name = "Heat Pipes",
-                desc = "+33% fire rate",
+                desc = "+23% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.33, weaponNum = 1})
                 end
             },
             [3] = {
                 name = "Nitrogen Tank",
-                desc = "+50% fire rate",
+                desc = "+17% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.5, weaponNum = 1})
                 end
             },
             [4] = {
                 name = "Sub Zero",
-                desc = "+75% fire rate",
+                desc = "+25% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.75, weaponNum = 1})
                 end
@@ -211,14 +211,14 @@ local HeroUpgradeDefs = {
             },
             [2] = {
                 name = "Autoloader",
-                desc = "+50% fire rate",
+                desc = "+20% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.5, weaponNum = 1})
                 end
             },
             [3] = {
                 name = "Double Salvo",
-                desc = "Two Salvos",
+                desc = "Two Salvos, reload upgrades reverted",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 1, "burst", 2)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.0, weaponNum = 1})
@@ -344,14 +344,14 @@ local HeroUpgradeDefs = {
             },
             [2] = {
                 name = "Autoloader",
-                desc = "+80% fire rate",
+                desc = "+30% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.8, weaponNum = 1})
                 end
             },
             [3] = {
                 name = "Double Salvo",
-                desc = "Two Salvos",
+                desc = "Two Salvos, reload upgrades reverted",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 1, "burst", 2)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.0, weaponNum = 1})
@@ -369,7 +369,7 @@ local HeroUpgradeDefs = {
             -- armour
             [1] = {
                 name = "Jump",
-                desc = "unlock jump",
+                desc = "Unlock jump",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     enableCmd(unitID, CMD_JUMP)
                 end
@@ -378,14 +378,14 @@ local HeroUpgradeDefs = {
                 name = "Light Armour",
                 desc = "+1000 HP",
                 upgrade = function(unitID, unitDefID, unitTeam)
-                    spSetUnitRulesParam(unitID, "armour", 2000)
+                    spSetUnitRulesParam(unitID, "armour", 1000)
                 end
             },
             [3] = {
                 name = "Medium Armour",
                 desc = "+1000 HP",
                 upgrade = function(unitID, unitDefID, unitTeam)
-                    spSetUnitRulesParam(unitID, "armour", 1000)
+                    spSetUnitRulesParam(unitID, "armour", 2000)
                 end
             },
             [4] = {
@@ -400,28 +400,28 @@ local HeroUpgradeDefs = {
             -- dgun
             [1] = {
                 name = "Puppy Spawner",
-                desc = "spawns 4 puppies",
+                desc = "Spawns 4 puppies",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     enableCmd(unitID, CMD.MANUALFIRE)
                 end
             },
             [2] = {
                 name = "Flock of Puppies",
-                desc = "spawns 6 puppies",
+                desc = "Spawns 6 puppies",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 2, "burst", 6)
                 end
             },
             [3] = {
                 name = "Herd of Puppies",
-                desc = "spawns 8 puppies",
+                desc = "Spawns 8 puppies",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 2, "burst", 8)
                 end
             },
             [4] = {
                 name = "Puppy Army",
-                desc = "spawns 12 puppies",
+                desc = "Spawns 12 puppies",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 2, "burst", 12)
                 end
@@ -477,21 +477,21 @@ local HeroUpgradeDefs = {
             },
             [2] = {
                 name = "Improved Firerate",
-                desc = "+40% fire rate",
+                desc = "+20% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.4, weaponNum = 1})
                 end
             },
             [3] = {
                 name = "Semi-Automatic",
-                desc = "+60% fire rate",
+                desc = "+20% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.6, weaponNum = 1})
                 end
             },
             [4] = {
                 name = "Belt-Fed",
-                desc = "+80% fire rate",
+                desc = "+20% fire rate",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.8, weaponNum = 1})
                 end
@@ -575,7 +575,7 @@ local HeroUpgradeDefs = {
             -- rocket weapon params
             [1] = {
                 name = "Fire Rockets",
-                desc = "enable 2x fire rocket weapons",
+                desc = "Enable 2x fire rocket weapons",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 1, "range", 460)
                 end
@@ -606,7 +606,7 @@ local HeroUpgradeDefs = {
             -- heatray weapon params
             [1] = {
                 name = "Double Heatray",
-                desc = "enable 2x heatray weapons",
+                desc = "Enable 2x heatray weapons",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 2, "range", 430)
                 end
@@ -644,7 +644,7 @@ local HeroUpgradeDefs = {
             -- regenamount displayed on healthbar does currently not update its value
             [1] = {
                 name = "Faster Repair",
-                desc = "reduce regentime to 5 sec",
+                desc = "Reduce regentime to 5 sec",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     GG.SetUnitIdleRegen(unitID, 150, 250)
                 end
@@ -699,6 +699,138 @@ local HeroUpgradeDefs = {
                 desc = "Fires 100 upgraded rockets, disables rocket attack while reloading",
                 upgrade = function(unitID, unitDefID, unitTeam)
                     spSetUnitWeaponState(unitID, 3, "burst", 50)
+                end
+            }
+        }
+    },
+    heromoderator = {
+        stats = {
+            minHP = 1200,
+            maxHP = 6000,
+            minScale = 1,
+            maxScale = 2
+        },
+        path1 = {
+            -- weapon dmg params
+            [1] = {
+                name = "Adv Beamlaser",
+                desc = "+1000 dmg, +1000 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 1, 2000)
+                end
+            },
+            [2] = {
+                name = "Engergy Cristal",
+                desc = "+1000 dmg, +1000 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 1, 3000)
+                end
+            },
+            [3] = {
+                name = "Beam Bundling",
+                desc = "+1000 dmg, +1000 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 1, 4000)
+                end
+            },
+            [4] = {
+                name = "Power Cristal",
+                desc = "+1000 dmg, +1000 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 1, 5000)
+                end
+            }
+        },
+        path2 = {
+            -- weapon fire params
+            [1] = {
+                name = "Cooling System",
+                desc = "+25% fire rate",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.25, weaponNum = 1})
+                end
+            },
+            [2] = {
+                name = "Adv Circuits",
+                desc = "+25% fire rate",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.5, weaponNum = 1})
+                end
+            },
+            [3] = {
+                name = "Cryo Stabylizer",
+                desc = "+25% fire rate",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    GG.Attributes.AddEffect(unitID, "weapon1", {reload = 1.75, weaponNum = 1})
+                end
+            },
+            [4] = {
+                name = "Resonant Conduit",
+                desc = "+25% fire rate",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    GG.Attributes.AddEffect(unitID, "weapon1", {reload = 2.0, weaponNum = 1})
+                end
+            }
+        },
+        path3 = {
+            -- speed
+            [1] = {
+                name = "Light Armour",
+                desc = "+1000 HP",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    spSetUnitRulesParam(unitID, "armour", 1000)
+                end
+            },
+            [2] = {
+                name = "Medium Armour",
+                desc = "+1000 HP",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    spSetUnitRulesParam(unitID, "armour", 2000)
+                end
+            },
+            [3] = {
+                name = "Adv Targeting",
+                desc = "+100 range",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    spSetUnitWeaponState(unitID, 1, "range", 520)
+                end
+            },
+            [4] = {
+                name = "Precision Module",
+                desc = "+100 range",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    spSetUnitWeaponState(unitID, 1, "range", 620)
+                end
+            }
+        },
+        path4 = {
+            -- dgun
+            [1] = {
+                name = "Disruptor Bomb",
+                desc = "Slows and damages in an area",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    enableCmd(unitID, CMD.MANUALFIRE)
+                end
+            },
+            [2] = {
+                name = "Time Distortion",
+                desc = "+350 dmg, +2100 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 2, 700)
+                end
+            },
+            [3] = {
+                name = "Chronomancy",
+                desc = "+350 dmg, +2100 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 2, 1050)
+                end
+            },
+            [4] = {
+                name = "Violet Slugger",
+                desc = "+450 dmg, +2700 slowdmg",
+                upgrade = function(unitID, unitDefID, unitTeam)
+                    setWeaponDamage(unitID, 2, 1500)
                 end
             }
         }

--- a/ZeroWars.sdd/LuaRules/Configs/Hero_Unit_Defs.lua
+++ b/ZeroWars.sdd/LuaRules/Configs/Hero_Unit_Defs.lua
@@ -773,7 +773,7 @@ local HeroUpgradeDefs = {
             }
         },
         path3 = {
-            -- speed
+            -- armour and range
             [1] = {
                 name = "Light Armour",
                 desc = "+1000 HP",

--- a/ZeroWars.sdd/gamedata/unit_tweaks.lua
+++ b/ZeroWars.sdd/gamedata/unit_tweaks.lua
@@ -18,6 +18,9 @@ local unit_tweaks = {
             morphto_5 = [[herodante]],
             morphcost_5 = 1,
             morphtime_5 = 1,
+            morphto_6 = [[heromoderator]],
+            morphcost_6 = 1,
+            morphtime_6 = 1,
         }
     },
     chicken = {

--- a/ZeroWars.sdd/scripts/heromoderator.lua
+++ b/ZeroWars.sdd/scripts/heromoderator.lua
@@ -1,0 +1,274 @@
+local support = piece 'support'
+local flare = piece 'flare'
+local eye_flare = piece 'eye_flare'
+local thigh1 = piece 'thigh1'
+local thigh2 = piece 'thigh2'
+local torso = piece 'torso'
+local head = piece 'head'
+local barrel = piece 'barrel'
+local foot2 = piece 'foot2'
+local foot1 = piece 'foot1'
+local leg2 = piece 'leg2'
+local leg1 = piece 'leg1'
+local shoulder = piece 'shoulder'
+local shoulder_left = piece 'shoulder_left'
+
+include "constants.lua"
+
+local aiming = false
+
+local RESTORE_DELAY = 2000
+
+-- Signal definitions
+local SIG_MOVE = 1
+local SIG_AIM = 2
+local SIG_RESTORE = 4
+
+local function walk()
+	Signal(SIG_MOVE)
+	SetSignalMask(SIG_MOVE)
+
+	while true do
+		if not aiming then
+			Move(torso, y_axis, -0.050000)
+			Turn(torso, x_axis, math.rad(1.758242))
+			Turn(torso, z_axis, math.rad(-0.703297))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(16.879121))
+		Turn(thigh2, x_axis, math.rad(-45.714286))
+		Turn(leg2, x_axis, math.rad(50.983516))
+		Turn(foot1, x_axis, math.rad(-16.527473))
+		Sleep(100)
+	
+		if not aiming then
+			Move(torso, y_axis, 0.000000)
+			Turn(torso, x_axis, math.rad(0.351648))
+			Turn(torso, z_axis, math.rad(-0.351648))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(24.263736))
+		Turn(thigh2, x_axis, math.rad(-41.137363))
+		Turn(leg2, x_axis, math.rad(43.247253))
+		Turn(foot1, x_axis, math.rad(-11.956044))
+		Sleep(102)
+	
+		if not aiming then
+			Turn(torso, x_axis, 0)
+			Turn(torso, z_axis, 0)
+		end
+		
+		Turn(thigh1, x_axis, math.rad(37.620879))
+		Turn(thigh2, x_axis, math.rad(-26.368132))
+		Turn(leg2, x_axis, math.rad(26.368132))
+		Turn(leg1, x_axis, math.rad(8.439560))
+		Sleep(104)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.300000)
+			Turn(torso, x_axis, 0)
+		end
+		
+		Turn(thigh1, x_axis, math.rad(22.148352))
+		Turn(thigh2, x_axis, math.rad(-11.956044))
+		Turn(leg2, x_axis, math.rad(11.598901))
+		Turn(leg1, x_axis, math.rad(27.428571))
+		Sleep(102)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.250000)
+			Turn(torso, x_axis, math.rad(1.758242))
+			Turn(torso, z_axis, math.rad(1.406593))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(3.159341))
+		Turn(thigh2, x_axis, math.rad(7.032967))
+		Turn(leg2, x_axis, math.rad(-1.054945))
+		Turn(foot2, x_axis, math.rad(-6.329670))
+		Turn(leg1, x_axis, math.rad(53.450549))
+		Sleep(102)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.100000)
+			Turn(torso, x_axis, math.rad(2.461538))
+			Turn(torso, z_axis, math.rad(0.703297))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-20.747253))
+		Turn(thigh2, x_axis, math.rad(20.747253))
+		Turn(foot2, x_axis, math.rad(-19.692308))
+		Turn(leg1, x_axis, math.rad(60.829670))
+		Sleep(103)
+
+		if not aiming then
+			Move(torso, y_axis, -0.050000)
+			Turn(torso, x_axis, math.rad(0.703297))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-39.384615))
+		Turn(thigh2, x_axis, math.rad(28.483516))
+		Turn(foot2, x_axis, math.rad(-27.076923))
+		Sleep(103)
+	
+		if not aiming then
+			Move(torso, y_axis, 0.000000)
+			Turn(torso, x_axis, math.rad(0.351648))
+			Turn(torso, z_axis, math.rad(0.351648))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-43.956044))
+		Turn(thigh2, x_axis, math.rad(34.813187))
+		Turn(foot2, x_axis, math.rad(-20.395604))
+		Turn(leg1, x_axis, math.rad(43.956044))
+		Turn(foot1, x_axis, 0)
+		Sleep(103)
+		
+		if not aiming then
+			Turn(torso, x_axis, 0)
+			Turn(torso, z_axis, 0)
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-31.994505))
+		Turn(thigh2, x_axis, math.rad(35.868132))
+		Turn(leg2, x_axis, math.rad(16.175824))
+		Turn(foot2, x_axis, math.rad(-13.714286))
+		Turn(leg1, x_axis, math.rad(32.351648))
+		Sleep(103)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.250000)
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-23.554945))
+		Turn(thigh2, x_axis, math.rad(23.560440))
+		Turn(leg2, x_axis, math.rad(40.434066))
+		Turn(leg1, x_axis, math.rad(24.263736))
+		Sleep(103)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.200000)
+			Turn(torso, x_axis, math.rad(2.109890))
+			Turn(torso, z_axis, math.rad(-2.109890))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(-1.406593))
+		Turn(thigh2, x_axis, math.rad(-14.412088))
+		Turn(leg2, x_axis, math.rad(69.269231))
+		Turn(leg1, x_axis, math.rad(2.461538))
+		Sleep(103)
+	
+		if not aiming then
+			Move(torso, y_axis, -0.150000)
+			Turn(torso, z_axis, math.rad(-1.054945))
+		end
+		
+		Turn(thigh1, x_axis, math.rad(11.604396))
+		Turn(thigh2, x_axis, math.rad(-35.164835))
+		Turn(leg2, x_axis, math.rad(76.659341))
+		Turn(foot1, x_axis, math.rad(-14.065934))
+		Sleep(103)
+	end
+end
+
+function script.Create()
+	Hide(flare)
+	Hide(support)
+	Hide(barrel)
+	StartThread(GG.Script.SmokeUnit, unitID, {torso})
+end
+
+function script.StartMoving()
+	StartThread(walk)
+end
+
+function script.StopMoving()
+	Signal(SIG_MOVE)
+	
+	Turn(thigh1, x_axis, 0)
+	Turn(thigh2, x_axis, 0)
+	Turn(leg2, x_axis, 0)
+	Turn(foot1, x_axis, 0)
+end
+
+
+local function RestoreAfterDelay()
+	Signal(SIG_RESTORE)
+	SetSignalMask(SIG_RESTORE)
+	Sleep(RESTORE_DELAY)
+	Turn(torso, y_axis, 0, math.rad(160))
+	Turn(head, x_axis, 0, math.rad(45))
+	aiming = false
+end
+
+function script.AimWeapon(num, heading, pitch)
+	Signal(SIG_AIM)
+	SetSignalMask(SIG_AIM)
+	StartThread(RestoreAfterDelay)
+	aiming = true
+	
+	-- The aim check messes with unit targeting. This is not required for Moderator as
+	-- it very rarely shoots at radar dots.
+	--GG.DontFireRadar_CheckAim(unitID)
+	
+	Turn(torso, y_axis, heading, math.rad(300))
+	Turn(head, x_axis, -pitch, math.rad(150))
+	WaitForTurn(torso, y_axis)
+	WaitForTurn(head, x_axis)
+	return true
+end
+
+function script.FireWeapon()
+	EmitSfx(eye_flare, 1024)
+	Spin(shoulder, x_axis, math.rad(485), math.rad(5))
+	Spin(shoulder_left, x_axis, math.rad(485), math.rad(5))
+	Sleep(6600)
+	Spin(shoulder, x_axis, 0, math.rad(5))
+	Spin(shoulder_left, x_axis, 0, math.rad(5))
+	Sleep(3100)
+	Turn(shoulder, x_axis, 0, math.rad(50))
+	Turn(shoulder_left, x_axis, 0, math.rad(50))
+end
+
+function script.QueryWeapon()
+	return eye_flare
+end
+
+function script.AimFromWeapon()
+	return head
+end
+
+function script.BlockShot(num, targetID)
+	return (targetID and GG.DontFireRadar_CheckBlock(unitID, targetID)) or false
+end
+
+function script.Killed(recentDamage, maxHealth)
+	local severity = recentDamage/maxHealth
+	if severity <= 0.25 then
+		Explode(foot1, SFX.NONE)
+		Explode(foot2, SFX.NONE)
+		Explode(leg1, SFX.NONE)
+		Explode(leg2, SFX.NONE)
+		Explode(thigh1, SFX.NONE)
+		Explode(thigh2, SFX.NONE)
+		Explode(torso, SFX.NONE)
+		return 1
+	elseif severity <= 0.50 then
+		Explode(foot1, SFX.NONE)
+		Explode(foot2, SFX.NONE)
+		Explode(leg1, SFX.NONE)
+		Explode(leg2, SFX.NONE)
+		Explode(thigh1, SFX.NONE)
+		Explode(thigh2, SFX.NONE)
+		Explode(torso, SFX.SHATTER)
+		return 1
+	end
+
+	Explode(foot1, SFX.SMOKE + SFX.FIRE)
+	Explode(foot2, SFX.SMOKE + SFX.FIRE)
+	Explode(leg1, SFX.SMOKE + SFX.FIRE)
+	Explode(leg2, SFX.SMOKE + SFX.FIRE)
+	Explode(thigh1, SFX.SMOKE + SFX.FIRE)
+	Explode(thigh2, SFX.SMOKE + SFX.FIRE)
+	Explode(torso, SFX.SHATTER)
+	return 2
+end

--- a/ZeroWars.sdd/units/heromoderator.lua
+++ b/ZeroWars.sdd/units/heromoderator.lua
@@ -1,0 +1,206 @@
+return { heromoderator = {
+  unitname            = [[heromoderator]],
+  name                = [[Hero Moderator]],
+  description         = [[Hero Disruptor Skirmisher Walker]],
+  acceleration        = 0.6,
+  activateWhenBuilt   = true,
+  brakeRate           = 3.6,
+  buildCostMetal      = 240,
+  builder             = false,
+  buildPic            = [[jumpskirm.png]],
+  canGuard            = true,
+  canMove             = true,
+  canPatrol           = true,
+  category            = [[LAND]],
+-- A box collision volume, while better matching the model, seems to increase friendly fire
+--  collisionVolumeOffsets        = [[0 0 0]],
+--  collisionVolumeScales         = [[30 30 20]],
+--  collisionVolumeType           = [[box]],
+  selectionVolumeOffsets = [[0 0 0]],
+  selectionVolumeScales  = [[42 42 42]],
+  selectionVolumeType    = [[ellipsoid]],
+  corpse              = [[DEAD]],
+
+  customParams        = {
+	hero = true,
+    dontfireatradarcommand = '1',
+    selection_scale   = 0.85,
+  },
+
+  explodeAs           = [[BIG_UNITEX]],
+  footprintX          = 3,
+  footprintZ          = 3,
+  iconType            = [[commander1]],
+  idleAutoHeal        = 250,
+  idleTime            = 200,
+  leaveTracks         = true,
+  maxDamage           = 1200,
+  maxSlope            = 36,
+  maxVelocity         = 1.5,
+  maxWaterDepth       = 22,
+  minCloakDistance    = 75,
+  movementClass       = [[KBOT3]],
+  noAutoFire          = false,
+  noChaseCategory     = [[TERRAFORM FIXEDWING SUB UNARMED]],
+  objectName          = [[CORMORT.s3o]],
+  script              = [[heromoderator.lua]],
+  selfDestructAs      = [[BIG_UNITEX]],
+
+  sfxtypes            = {
+
+    explosiongenerators = {
+      [[custom:NONE]],
+    },
+
+  },
+
+  sightDistance       = 420,
+  trackOffset         = 0,
+  trackStrength       = 8,
+  trackStretch        = 0.8,
+  trackType           = [[ComTrack]],
+  trackWidth          = 14,
+  turnRate            = 2400,
+  upright             = true,
+  canManualFire 	  = true,
+  workerTime          = 0,
+
+  weapons             = {
+
+    {
+      def                = [[DISRUPTOR_BEAM]],
+      badTargetCategory  = [[FIXEDWING UNARMED]],
+      onlyTargetCategory = [[FIXEDWING LAND SINK TURRET SHIP SWIM FLOAT GUNSHIP HOVER]],
+    },
+	{
+      def 				 = [[DISRUPTOR_BOMB]],
+      badTargetCategory  = [[FIXEDWING]],
+      onlyTargetCategory = [[FIXEDWING LAND SINK TURRET SHIP SWIM FLOAT GUNSHIP HOVER]]
+    }    
+	
+  },
+
+
+  weaponDefs          = {
+
+    DISRUPTOR_BEAM = {
+    name                    = [[Disruptor Pulse Beam]],
+      areaOfEffect            = 32,
+      beamdecay               = 0.9,
+      beamTime                = 1/30,
+      beamttl                 = 30,
+      coreThickness           = 0.25,
+      craterBoost             = 0,
+      craterMult              = 0,
+      
+      customparams = {
+        burst = Shared.BURST_RELIABLE,
+
+        timeslow_damagefactor = 1,
+        timeslow_overslow_frames = 2*30,
+        
+        light_color = [[1.88 0.63 2.5]],
+        light_radius = 320,
+      },
+
+      damage                  = {
+          default = 1000.1,
+      },
+      
+      explosionGenerator      = [[custom:flash2purple]],
+      fireStarter             = 30,
+      impactOnly              = true,
+      impulseBoost            = 0,
+      impulseFactor           = 0.4,
+      interceptedByShieldType = 1,
+      largeBeamLaser          = true,
+      laserFlareSize          = 4.33,
+      minIntensity            = 1,
+      noSelfDamage            = true,
+      range                   = 420,
+      reloadtime              = 10,
+      rgbColor                = [[0.3 0 0.4]],
+      soundStart              = [[weapon/laser/heavy_laser5]],
+      soundStartVolume        = 3.8,
+      soundTrigger            = true,
+      texture1                = [[largelaser]],
+      texture2                = [[flare]],
+      texture3                = [[flare]],
+      texture4                = [[smallflare]],
+      thickness               = 12,
+      tolerance               = 18000,
+      turret                  = true,
+      weaponType              = [[BeamLaser]],
+      weaponVelocity          = 500,
+    },
+    DISRUPTOR_BOMB = {
+    name                    = [[Disruptor Bomb]],
+	accuracy                = 256,
+	areaOfEffect            = 300,
+	cegTag                  = [[beamweapon_muzzle_purple]],
+	commandFire             = true,
+	craterBoost             = 0,
+	craterMult              = 0,
+
+	customParams            = {
+		timeslow_damagefactor = [[6]],
+		muzzleEffectFire = [[custom:RAIDMUZZLE]],
+		nofriendlyfire = "needs hax",
+
+		light_camera_height = 2500,
+		light_color = [[1.5 0.75 1.8]],
+		light_radius = 280,
+		reaim_time = 1,
+	},
+
+	damage                  = {
+		default = 350,
+		subs    = 17.5,
+	},
+
+	explosionGenerator      = [[custom:riotballplus2_purple]],
+	explosionSpeed          = 5,
+	fireStarter             = 100,
+	impulseBoost            = 0,
+	impulseFactor           = 0,
+	interceptedByShieldType = 2,
+	model                   = [[wep_b_fabby.s3o]],
+	range                   = 450,
+	reloadtime              = 25,
+	smokeTrail              = true,
+    soundHit                = [[weapon/aoe_aura2]],
+	soundHitVolume          = 8,
+	soundStart              = [[weapon/cannon/cannon_fire3]],
+	--startVelocity           = 350,
+	--trajectoryHeight        = 0.3,
+	turret                  = true,
+	weaponType              = [[Cannon]],
+	weaponVelocity          = 350,
+	}
+  },
+
+
+  featureDefs         = {
+
+    DEAD  = {
+      blocking         = true,
+      featureDead      = [[HEAP]],
+      footprintX       = 2,
+      footprintZ       = 2,
+      collisionVolumeOffsets        = [[0 -5 -15]],
+      collisionVolumeScales         = [[20 20 30]],
+      collisionVolumeType           = [[box]],
+      object           = [[cormort_dead_no_gun.s3o]],
+    },
+
+
+    HEAP  = {
+      blocking    = false,
+      footprintX  = 2,
+      footprintZ  = 2,
+      object      = [[debris2x2a.s3o]],
+    },
+
+  },
+
+} }


### PR DESCRIPTION
The upgrade descriptions were in my opinion partially misleading as you had to remember the old upgrade values to know the actual upgrade bonus.
Made descriptions start with capital letter.
Puppy armor upgrade was 2000->1000 effectively reducing hp with second upgrade.