### PR TITLE
PROPOSAL: Award metal on Hero Kill

### DIFF
--- a/ZeroWars.sdd/luarules/gadgets/unit_heroes/respawn_pool.lua
+++ b/ZeroWars.sdd/luarules/gadgets/unit_heroes/respawn_pool.lua
@@ -39,6 +39,14 @@ function RespawnPool:_OnHeroDeath(hero, currentFrame, deathFrame)
     local respawnFrame = 4 * (30) * (hero:getLevel() + 1) + currentFrame
     table.insert(self._pool, {hero = hero, deathFrame = deathFrame, respawnFrame = respawnFrame})
 
+    local teamlist = Spring.GetTeamList()
+    local myTeamId = Spring.GetUnitTeam(hero._ID)
+    for _, teamID in pairs(teamlist) do   
+        if teamID ~= myTeamId then
+            Spring.AddTeamResource(teamID, "metal", 200)
+        end
+    end	
+	
     hero:heal()
     hero:setPosition(self._deathPoint)
     Spring.SetUnitNeutral(hero._ID, true)


### PR DESCRIPTION
There is currently no penalty to letting your hero die carelessly.
This would be discouraged by giving the other team a small amount of metal whenever they kill your hero.